### PR TITLE
Remove pkg-resources from requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 Django==1.10.4
-pkg-resources==0.0.0
 python-postmark==0.4.10
 requests==2.12.4


### PR DESCRIPTION
pkg-resources shall not be present in requirements file
it does exist due to a bug in ubuntu
https://github.com/pypa/pip/issues/4022

This commit fixes https://github.com/jadijadi/bestoon/issues/3