### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.js linguist-language=Python


### PR DESCRIPTION
now Github detects bestoon as a python project instead of a js project

Github is using [linguist](https://github.com/github/linguist/) for detecting language of repositories 
and it's behavior can be [overridden](https://github.com/github/linguist/#troubleshooting)

This pull request overrides it and counts all js files as python files     