### PR TITLE
return objects in json format (for news,query_incomes,query_expense)

### DIFF
--- a/web/models.py
+++ b/web/models.py
@@ -34,6 +34,9 @@ class Expense(models.Model):
     amount = models.BigIntegerField()
     user = models.ForeignKey(User)
 
+    def isoformat(self):
+        return {'text': self.text, 'amount': self.amount, 'date': self.date}
+
     def __unicode__(self):
         return "{}-{}-{}".format(self.date, self.user, self.amount)
 
@@ -43,6 +46,9 @@ class Income(models.Model):
     date = models.DateTimeField()
     amount = models.BigIntegerField()
     user = models.ForeignKey(User)
+
+    def isoformat(self):
+        return {'text': self.text, 'amount': self.amount, 'date': self.date}
 
     def __unicode__(self):
         return "{}-{}-{}".format(self.date, self.user, self.amount)

--- a/web/models.py
+++ b/web/models.py
@@ -1,8 +1,7 @@
 from __future__ import unicode_literals
-from django.utils.crypto import get_random_string
-from django.db import models
-from django.contrib.auth.models import User
 
+from django.contrib.auth.models import User
+from django.db import models
 
 
 class News(models.Model):
@@ -35,7 +34,7 @@ class Expense(models.Model):
     user = models.ForeignKey(User)
 
     def isoformat(self):
-        return {'text': self.text, 'amount': self.amount, 'date': self.date}
+        return {'id': self.pk, 'text': self.text, 'amount': self.amount, 'date': self.date}
 
     def __unicode__(self):
         return "{}-{}-{}".format(self.date, self.user, self.amount)
@@ -48,7 +47,7 @@ class Income(models.Model):
     user = models.ForeignKey(User)
 
     def isoformat(self):
-        return {'text': self.text, 'amount': self.amount, 'date': self.date}
+        return {'id': self.pk, 'text': self.text, 'amount': self.amount, 'date': self.date}
 
     def __unicode__(self):
         return "{}-{}-{}".format(self.date, self.user, self.amount)

--- a/web/utils.py
+++ b/web/utils.py
@@ -1,8 +1,13 @@
 # -*- coding: utf-8 -*-
 
+import time
+from datetime import datetime
+from json import JSONEncoder
+
 import requests
 from django.conf import settings
-import time
+
+from .models import Income, Expense
 
 
 def RateLimited(maxPerSecond):  # a decorator. @RateLimited(10) will let 10 runs in 1 seconds
@@ -44,3 +49,11 @@ def grecaptcha_verify(request):
     verify_rs = requests.get(url, params=params, verify=True)
     verify_rs = verify_rs.json()
     return verify_rs.get("success", False)
+
+
+class CustomJSONEncoder(JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, (datetime, Expense, Income)):
+            return obj.isoformat()
+        else:
+            return JSONEncoder.default(self, obj)

--- a/web/views.py
+++ b/web/views.py
@@ -21,11 +21,11 @@ from .models import User, Token, Expense, Income, Passwordresetcodes, News
 # Create your views here.
 from postmark import PMMail
 
-from .utils import grecaptcha_verify, RateLimited
+from .utils import grecaptcha_verify, RateLimited,CustomJSONEncoder
 
 # create random string for Toekn
-random_str = lambda N: ''.join(
-    random.SystemRandom().choice(string.ascii_uppercase + string.ascii_lowercase + string.digits) for _ in range(N))
+#random_str = lambda N: ''.join(
+#    random.SystemRandom().choice(string.ascii_uppercase + string.ascii_lowercase + string.digits) for _ in range(N))
 
 
 # login , (API) , returns : JSON = statuns (ok|error) and token
@@ -34,9 +34,8 @@ random_str = lambda N: ''.join(
 
 @csrf_exempt
 def news(request):
-    news = News.objects.all().order_by('-date')[:11]
-    news_serialized = serializers.serialize("json", news)
-    return JsonResponse(news_serialized, encoder=JSONEncoder, safe=False)
+    news_list = list(News.objects.all().order_by('-date')[:11].values())
+    return JsonResponse({'news': news_list}, encoder=CustomJSONEncoder)
 
 
 @csrf_exempt
@@ -167,9 +166,8 @@ def query_expenses(request):
     this_token = request.POST['token']
     num = request.POST.get('num', 10)
     this_user = get_object_or_404(User, token__token=this_token)
-    expenses = Expense.objects.filter(user=this_user).order_by('-date')[:num]
-    expenses_serialized = serializers.serialize("json", expenses)
-    return JsonResponse(expenses_serialized, encoder=JSONEncoder, safe=False)
+    expenses_list = list(Expense.objects.filter(user=this_user).order_by('-date')[:num])
+    return JsonResponse({'expenses': expenses_list}, encoder=CustomJSONEncoder)
 
 
 @csrf_exempt
@@ -178,9 +176,8 @@ def query_incomes(request):
     this_token = request.POST['token']
     num = request.POST.get('num', 10)
     this_user = get_object_or_404(User, token__token=this_token)
-    incomes = Income.objects.filter(user=this_user).order_by('-date')[:num]
-    incomes_serialized = serializers.serialize("json", incomes)
-    return JsonResponse(incomes_serialized, encoder=JSONEncoder, safe=False)
+    incomes_list = list(Income.objects.filter(user=this_user).order_by('-date')[:num])
+    return JsonResponse({'incomes': incomes_list}, encoder=CustomJSONEncoder)
 
 
 @csrf_exempt


### PR DESCRIPTION
i write a custom json encoder to encode incomes,expense and news to right formated json. serializers.serialize() method that used in code return serialized object in string format and deserialize it in other languages(like java for android clients) is very very difficult.